### PR TITLE
Add support for Debian/Ubuntu

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,7 @@ class varnish::config (
     content => $vcl_content,
   }
 
-    case $operatingsystem {
+    case $::operatingsystem {
         debian:   { $use_sysctl = false }
         ubuntu:   { $use_sysctl = false }
         centos:   { $use_sysctl = true }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,12 +40,29 @@ class varnish::config (
     content => $vcl_content,
   }
 
-  file { '/etc/sysconfig/varnish':
-    ensure  => file,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0444',
-    content => template('varnish/varnish.sysctl.erb'),
-  }
+    case $operatingsystem {
+        debian:   { $use_sysctl = false }
+        ubuntu:   { $use_sysctl = false }
+        centos:   { $use_sysctl = true }
+        redhat:   { $use_sysctl = true }
+        default:  { $use_sysctl = true }
+    }
 
+    if $use_sysctl {
+        file { '/etc/sysconfig/varnish':
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0444',
+            content => template('varnish/varnish.sysctl.erb'),
+        }
+    } else {
+        file { '/etc/default/varnish':
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0444',
+            content => template('varnish/varnish.default.erb'),
+        }
+    }
 }

--- a/templates/varnish.default.erb
+++ b/templates/varnish.default.erb
@@ -1,0 +1,106 @@
+# Configuration file for varnish
+#
+# /etc/init.d/varnish expects the variables $DAEMON_OPTS, $NFILES and $MEMLOCK
+# to be set from this shell script fragment.
+#
+
+# Should we start varnishd at boot?  Set to "no" to disable.
+START=yes
+
+# Maximum number of open files (for ulimit -n)
+NFILES=131072
+
+# Maximum locked memory size (for ulimit -l)
+# Used for locking the shared memory log in memory.  If you increase log size,
+# you need to increase this number as well
+MEMLOCK=82000
+
+# Default varnish instance name is the local nodename.  Can be overridden with
+# the -n switch, to have more instances on a single server.
+# INSTANCE=$(uname -n)
+
+# This file contains 4 alternatives, please use only one.
+
+## Alternative 1, Minimal configuration, no VCL
+#
+# Listen on port 6081, administration on localhost:6082, and forward to
+# content server on localhost:8080.  Use a 1GB fixed-size cache file.
+#
+# DAEMON_OPTS="-a :6081 \
+#              -T localhost:6082 \
+# 	     -b localhost:8080 \
+# 	     -u varnish -g varnish \
+#            -S /etc/varnish/secret \
+# 	     -s file,/var/lib/varnish/$INSTANCE/varnish_storage.bin,1G"
+
+
+## Alternative 2, Configuration with VCL
+#
+# Listen on port 6081, administration on localhost:6082, and forward to
+# one content server selected by the vcl file, based on the request.  Use a 1GB
+# fixed-size cache file.
+#
+DAEMON_OPTS="-a :6081 \
+             -T localhost:6082 \
+             -f /etc/varnish/default.vcl \
+             -S /etc/varnish/secret \
+             -s malloc,256m"
+
+
+## Alternative 3, Advanced configuration
+#
+# See varnishd(1) for more information.
+#
+# # Main configuration file. You probably want to change it :)
+# VARNISH_VCL_CONF=/etc/varnish/default.vcl
+#
+# # Default address and port to bind to
+# # Blank address means all IPv4 and IPv6 interfaces, otherwise specify
+# # a host name, an IPv4 dotted quad, or an IPv6 address in brackets.
+# VARNISH_LISTEN_ADDRESS=
+# VARNISH_LISTEN_PORT=6081
+#
+# # Telnet admin interface listen address and port
+# VARNISH_ADMIN_LISTEN_ADDRESS=127.0.0.1
+# VARNISH_ADMIN_LISTEN_PORT=6082
+#
+# # The minimum number of worker threads to start
+# VARNISH_MIN_THREADS=1
+#
+# # The Maximum number of worker threads to start
+# VARNISH_MAX_THREADS=1000
+#
+# # Idle timeout for worker threads
+# VARNISH_THREAD_TIMEOUT=120
+#
+# # Cache file location
+# VARNISH_STORAGE_FILE=/var/lib/varnish/$INSTANCE/varnish_storage.bin
+#
+# # Cache file size: in bytes, optionally using k / M / G / T suffix,
+# # or in percentage of available disk space using the % suffix.
+# VARNISH_STORAGE_SIZE=1G
+#
+# # File containing administration secret
+# VARNISH_SECRET_FILE=/etc/varnish/secret
+# 
+# # Backend storage specification
+# VARNISH_STORAGE="file,${VARNISH_STORAGE_FILE},${VARNISH_STORAGE_SIZE}"
+#
+# # Default TTL used when the backend does not specify one
+# VARNISH_TTL=120
+#
+# # DAEMON_OPTS is used by the init script.  If you add or remove options, make
+# # sure you update this section, too.
+# DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
+#              -f ${VARNISH_VCL_CONF} \
+#              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
+#              -t ${VARNISH_TTL} \
+#              -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
+# 	       -S ${VARNISH_SECRET_FILE} \
+#              -s ${VARNISH_STORAGE}"
+#
+
+
+## Alternative 4, Do It Yourself
+#
+# DAEMON_OPTS=""

--- a/templates/varnish.default.erb
+++ b/templates/varnish.default.erb
@@ -1,3 +1,5 @@
+# Managed by puppet - Do not modify!
+
 # Configuration file for varnish
 #
 # /etc/init.d/varnish expects the variables $DAEMON_OPTS, $NFILES and $MEMLOCK
@@ -5,7 +7,11 @@
 #
 
 # Should we start varnishd at boot?  Set to "no" to disable.
+<% if scope.lookupvar('enable') then %>
 START=yes
+<% else %>
+START=no
+<% end %>
 
 # Maximum number of open files (for ulimit -n)
 NFILES=131072
@@ -15,92 +21,14 @@ NFILES=131072
 # you need to increase this number as well
 MEMLOCK=82000
 
-# Default varnish instance name is the local nodename.  Can be overridden with
-# the -n switch, to have more instances on a single server.
-# INSTANCE=$(uname -n)
-
-# This file contains 4 alternatives, please use only one.
-
-## Alternative 1, Minimal configuration, no VCL
+# Listen on port <%= scope.lookupvar('listen_address') %>:<%= scope.lookupvar('listen_port') %>, administration on <%= scope.lookupvar('admin_listen_address') %>:<%= scope.lookupvar('admin_listen_port') %>, and forward to
+# one content server selected by the vcl file, based on the request.  Use a <%= scope.lookupvar('storage_size') %>GB
+# fixed-size cache.
 #
-# Listen on port 6081, administration on localhost:6082, and forward to
-# content server on localhost:8080.  Use a 1GB fixed-size cache file.
-#
-# DAEMON_OPTS="-a :6081 \
-#              -T localhost:6082 \
-# 	     -b localhost:8080 \
-# 	     -u varnish -g varnish \
-#            -S /etc/varnish/secret \
-# 	     -s file,/var/lib/varnish/$INSTANCE/varnish_storage.bin,1G"
-
-
-## Alternative 2, Configuration with VCL
-#
-# Listen on port 6081, administration on localhost:6082, and forward to
-# one content server selected by the vcl file, based on the request.  Use a 1GB
-# fixed-size cache file.
-#
-DAEMON_OPTS="-a :6081 \
-             -T localhost:6082 \
+DAEMON_OPTS="-a <%= scope.lookupvar('listen_address') %>:<%= scope.lookupvar('listen_port') %> \
+             -T <%= scope.lookupvar('admin_listen_address') %>:<%= scope.lookupvar('admin_listen_port') %> \
+             -t <%= scope.lookupvar('ttl') %> \
              -f /etc/varnish/default.vcl \
-             -S /etc/varnish/secret \
-             -s malloc,256m"
-
-
-## Alternative 3, Advanced configuration
-#
-# See varnishd(1) for more information.
-#
-# # Main configuration file. You probably want to change it :)
-# VARNISH_VCL_CONF=/etc/varnish/default.vcl
-#
-# # Default address and port to bind to
-# # Blank address means all IPv4 and IPv6 interfaces, otherwise specify
-# # a host name, an IPv4 dotted quad, or an IPv6 address in brackets.
-# VARNISH_LISTEN_ADDRESS=
-# VARNISH_LISTEN_PORT=6081
-#
-# # Telnet admin interface listen address and port
-# VARNISH_ADMIN_LISTEN_ADDRESS=127.0.0.1
-# VARNISH_ADMIN_LISTEN_PORT=6082
-#
-# # The minimum number of worker threads to start
-# VARNISH_MIN_THREADS=1
-#
-# # The Maximum number of worker threads to start
-# VARNISH_MAX_THREADS=1000
-#
-# # Idle timeout for worker threads
-# VARNISH_THREAD_TIMEOUT=120
-#
-# # Cache file location
-# VARNISH_STORAGE_FILE=/var/lib/varnish/$INSTANCE/varnish_storage.bin
-#
-# # Cache file size: in bytes, optionally using k / M / G / T suffix,
-# # or in percentage of available disk space using the % suffix.
-# VARNISH_STORAGE_SIZE=1G
-#
-# # File containing administration secret
-# VARNISH_SECRET_FILE=/etc/varnish/secret
-# 
-# # Backend storage specification
-# VARNISH_STORAGE="file,${VARNISH_STORAGE_FILE},${VARNISH_STORAGE_SIZE}"
-#
-# # Default TTL used when the backend does not specify one
-# VARNISH_TTL=120
-#
-# # DAEMON_OPTS is used by the init script.  If you add or remove options, make
-# # sure you update this section, too.
-# DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
-#              -f ${VARNISH_VCL_CONF} \
-#              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
-#              -t ${VARNISH_TTL} \
-#              -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
-# 	       -S ${VARNISH_SECRET_FILE} \
-#              -s ${VARNISH_STORAGE}"
-#
-
-
-## Alternative 4, Do It Yourself
-#
-# DAEMON_OPTS=""
+             -S <%= scope.lookupvar('secret_file') %> \
+             -s "malloc,<%= scope.lookupvar('storage_size') %>" \
+             -w <%= scope.lookupvar('min_threads') %>,<%= scope.lookupvar('max_threads') %>,<%= scope.lookupvar('thread_timeout') %>"


### PR DESCRIPTION
Hi,

I wanted to use this module on an Ubuntu server. As there's no /etc/sysconfig/varnish on Debian flavored machines, I've added an OS switch to switch between /etc/sysconfig/varnish and /etc/default/varnish.

Jeroen
