### PR TITLE
Fix expeced file location for debian based systems (non sysctl based init)

### DIFF
--- a/templates/varnish.default.erb
+++ b/templates/varnish.default.erb
@@ -28,7 +28,7 @@ MEMLOCK=82000
 DAEMON_OPTS="-a <%= scope.lookupvar('listen_address') %>:<%= scope.lookupvar('listen_port') %> \
              -T <%= scope.lookupvar('admin_listen_address') %>:<%= scope.lookupvar('admin_listen_port') %> \
              -t <%= scope.lookupvar('ttl') %> \
-             -f /etc/varnish/default.vcl \
+             -f /etc/varnish/varnish.vcl \
              -S <%= scope.lookupvar('secret_file') %> \
              -s "malloc,<%= scope.lookupvar('storage_size') %>" \
              -w <%= scope.lookupvar('min_threads') %>,<%= scope.lookupvar('max_threads') %>,<%= scope.lookupvar('thread_timeout') %>"


### PR DESCRIPTION
Content is stored in /etc/varnish/varnish.vcl but init script uses /etc/varnish/default.vcl config file. This patch fixes that.
