### PR TITLE
Switched out broken enable option for working start option

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,6 +25,7 @@ class varnish::config (
   $thread_timeout,
   $storage_size,
   $ttl,
+  $start,
 ){
 
   # TODO - need to make varnish.d directory and populate with a define

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,6 +82,7 @@ class varnish(
   $thread_timeout       = 120,
   $storage_size         = '100M',
   $ttl                  = 120,
+  $start                = true,
 ) {
 
   class { 'varnish::install':
@@ -100,6 +101,7 @@ class varnish(
     thread_timeout        => $thread_timeout,
     storage_size          => $storage_size,
     ttl                   => $ttl,
+    start                 => $start,
   }
   class { 'varnish::service': }
 

--- a/templates/varnish.default.erb
+++ b/templates/varnish.default.erb
@@ -7,7 +7,7 @@
 #
 
 # Should we start varnishd at boot?  Set to "no" to disable.
-<% if scope.lookupvar('enable') then %>
+<% if scope.lookupvar('start') then %>
 START=yes
 <% else %>
 START=no

--- a/templates/varnish.sysctl.erb
+++ b/templates/varnish.sysctl.erb
@@ -1,5 +1,18 @@
 # Managed by puppet - Do not modify!
 
+# Configuration file for varnish
+#
+# /etc/init.d/varnish expects the variables $DAEMON_OPTS, $NFILES and $MEMLOCK
+# to be set from this shell script fragment.
+#
+
+# Should we start varnishd at boot?  Set to "no" to disable.
+<% if scope.lookupvar('start') then %>
+START=yes
+<% else %>
+START=no
+<% end %>
+
 # Maximum number of open files (for ulimit -n)
 NFILES=131072
 


### PR DESCRIPTION
I don't understand how `enable=true` is meant to be set in https://github.com/evenup/evenup-varnish/blob/master/templates/varnish.default.erb#L10

I am building a new Puppet 3 stack based on old Puppet 2 manifests, and we use your module.

I have absolutely no idea how Varnish is set to `START=yes` on our Puppet 2 managed servers. We did not set `$enable = true` anywhere. As expected on the new Puppet 3 stack, this equates to `START=no`, unless I set `$enable = true` in the node, or another parent scope.

In the Puppet 3 setup I am currently setting it in my default node that the others extend from (bad practice, I know), which does make it work, but is incredibly strange and obscure. If I include this module I expect Varnish to be on, or at the very least to be able to enable it via a class param or Hiera – either way, off is a very strange default.

I am just curious, how did you intend people to enable Varnish? Am I missing something?

My best guess as to how this "worked" is that it's a quirk based on the problems with `scope.lookupvar`'s handling of undefined variables described at https://docs.puppetlabs.com/guides/templating.html#testing-for-undefined-variables... not sure how absense would every equate to true though, very strange.
