### PR TITLE
Removed lookup since it doesn't work on Puppet 3.

### DIFF
--- a/templates/varnish.default.erb
+++ b/templates/varnish.default.erb
@@ -7,11 +7,8 @@
 #
 
 # Should we start varnishd at boot?  Set to "no" to disable.
-<% if scope.lookupvar('enable') then %>
 START=yes
-<% else %>
-START=no
-<% end %>
+
 
 # Maximum number of open files (for ulimit -n)
 NFILES=131072


### PR DESCRIPTION
It will always enable Varnish. This lookup was not working on Puppet 3 and the default state was not running, which took quite a while to figure out! :)
